### PR TITLE
Add random color option to color command

### DIFF
--- a/crimsobot/cogs/utilities.py
+++ b/crimsobot/cogs/utilities.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import random
 from datetime import datetime
 from typing import List, Optional, Tuple
 
@@ -169,8 +170,12 @@ class Utilities(commands.Cog):
         await msg.edit(content='<:ping:569954524932997122>...{:d}ms'.format(int(ping)))
 
     @commands.command()
-    async def color(self, ctx: commands.Context, hex_value: discord.Colour) -> None:
-        """Get color sample from hex value."""
+    async def color(self, ctx: commands.Context, hex_value: Optional[discord.Colour] = None) -> None:
+        """Get color sample from hex value. Or a random one!"""
+
+        if hex_value is None:
+            random_int = random.randint(0, 0xFFFFFF)
+            hex_value = discord.Colour(random_int)
 
         fp = imagetools.make_color_img(str(hex_value))
         await ctx.send(


### PR DESCRIPTION
Allow the `/color` command to generate a random color if no hex value is provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-2eddd03d-6c95-4403-97ad-003c71bc8f76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2eddd03d-6c95-4403-97ad-003c71bc8f76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

